### PR TITLE
Update ci jobs so that they don't fail

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,5 +24,6 @@ jobs:
       run: dotnet build --no-restore -c Release
       working-directory: Backend/ProReLe.Application
     - name: Test
-      run: dotnet test --no-build -c Release --verbosity normal
+      #run: dotnet test --no-build -c Release --verbosity normal
+      run: cd Backend/ProReLe.Tests/bin/Release/net6.0; ls
       working-directory: Backend/ProReLe.Tests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
-      run: cd Backend; ls
+      run: cd Backend/ProRele; ls
       # working-directory: Backend/ProReLe/ProRele.sln
     - name: Build
       run: dotnet build --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,5 +24,5 @@ jobs:
       run: dotnet build --no-restore
       working-directory: Backend/ProReLe.Application
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --verbosity normal
       working-directory: Backend/ProReLe.Tests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,3 +25,4 @@ jobs:
       working-directory: Backend/ProReLe.Application
     - name: Test
       run: dotnet test --no-build --verbosity normal
+      working-directory: Backend/ProReLe.Tests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,9 +21,8 @@ jobs:
       run: dotnet restore
       working-directory: Backend/ProReLe.Application
     - name: Build
-      run: dotnet build --no-restore -c Release
+      run: dotnet build --no-restore
       working-directory: Backend/ProReLe.Application
     - name: Test
-      #run: dotnet test --no-build -c Release --verbosity normal
-      run: cd Backend/ProReLe.Tests/bin/Release/net6.0; ls
+      run: dotnet test --no-build --verbosity normal
       working-directory: Backend/ProReLe.Tests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
         dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
-      working-directory: Backend/Prorele
+      working-directory: Backend/ProReLe
     - name: Build
       run: dotnet build --no-restore
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,8 +21,8 @@ jobs:
       run: dotnet restore
       working-directory: Backend/ProReLe.Application
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore -c Release
       working-directory: Backend/ProReLe.Application
     - name: Test
-      run: dotnet test --verbosity normal
+      run: dotnet test --no-build -c Release --verbosity normal
       working-directory: Backend/ProReLe.Tests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
         dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
-      working-directory: Backend/ProReLe
+      working-directory: ./Backend/ProReLe/ProRele.sln
     - name: Build
       run: dotnet build --no-restore
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,5 +22,6 @@ jobs:
       working-directory: Backend/ProReLe.Application
     - name: Build
       run: dotnet build --no-restore
+      working-directory: Backend/ProReLe.Application
     - name: Test
       run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
         dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
-      working-directory: src/Prorele/Backend/Prorele
+      working-directory: Backend/Prorele
     - name: Build
       run: dotnet build --no-restore
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
-      run: ls
+      run: cd Backend; ls
       # working-directory: Backend/ProReLe/ProRele.sln
     - name: Build
       run: dotnet build --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,8 +18,8 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
-      run: dotnet restore
-      working-directory: ./Backend/ProReLe/ProRele.sln
+      run: ls
+      # working-directory: Backend/ProReLe/ProRele.sln
     - name: Build
       run: dotnet build --no-restore
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,6 +19,7 @@ jobs:
         dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
+      working-directory: src/Prorele/Backend/Prorele
     - name: Build
       run: dotnet build --no-restore
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,8 +18,8 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
-      run: cd Backend/ProRele; ls
-      # working-directory: Backend/ProReLe/ProRele.sln
+      run: dotnet restore
+      working-directory: Backend/ProReLe.Application
     - name: Build
       run: dotnet build --no-restore
     - name: Test


### PR DESCRIPTION
- Foram atualizados os working directories de todos os jobs
- Foi removido o arg `--no-build` do job de testes. Esse argumento fazia com que a pipeline procurasse um dll (arquivo compilado) do projeto de testes. Porém, o job de build nunca fazia a build do projeto de testes pois o projeto de testes não é uma dependência do projeto de application. Ou seja, o job de testes falhava porque ele nunca era buildado. Remover o `--no-build` resolve esse problema porque daí o job de testes vai realizar a build do projeto de testes na hora
- O job de testes ainda estará falhando, mas isso ocorre porque os testes ainda não estão mockando o retorno do DB